### PR TITLE
Fix for toggling code lists

### DIFF
--- a/gsdemo2/GSDEMO2.c
+++ b/gsdemo2/GSDEMO2.c
@@ -57,8 +57,8 @@ printf("\nDone.  Press [Enter] to continue.");
 getchar();
 
 printf("\n\nNext to toggle the code lists.");
-printf("\nThey were %s",GetCodeState(g) ? "on":"off");
-printf(" and now they are %s\n(hopefully that reads off!)",SetCodeState(g,0) ? "on":"off");
+printf("\nThey were %s", GetCodeState(g) ? "off":"on");
+printf(" and now they are %s", SetCodeState(g,-1) ? "off":"on");
 
 // Disable this test for now as the editor doesn't seem to work with this
 // modification.


### PR DESCRIPTION
Before, it always set the code state to “on” even though it would print
out “off”. The strings in the ternary operator were reversed.

Feeding in -1 as the second argument to SetCodeState toggles it, as
opposed to 0, which sets it to “on”.
